### PR TITLE
Proper mediaType validation

### DIFF
--- a/xfileindex/xfileindex.py
+++ b/xfileindex/xfileindex.py
@@ -98,9 +98,10 @@ SUPPORTED_MEDIA_TYPES = [
 
 
 def process_file(file, mediaType):
-    if mediaType == "text/plain" or mediaType == "text/csv":
+    mediaType = mediaType.lower() # consistency 
+    if mediaType.startswith("text/plain") or mediaType.startswith("text/csv"):
         chunked_text = process_text_file(file)
-    elif mediaType == "application/pdf":
+    elif mediaType.startswith("application/pdf"):
         chunked_text = process_pdf_file(file)
     else:
         chunked_text = []


### PR DESCRIPTION
- lowercased the `mediaType` value to ensure consistency of user input
- change from exact matching to prefix matching as some mime types can carry further meta data like `application/pdf;charset=utf8` these occurrences would not be matched with the equal comparision